### PR TITLE
feat: Add support for Consent State

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
         "before": true,
         "beforeEach": true,
         "after": true,
+        "afterEach": true,
         "uetq": true,
         "UET": true
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
         "lint:fix": "eslint src/ test/src/ --fix",
         "test": "npm run build && npm run build:test && DEBUG=false karma start test/karma.config.js",
         "test:debug": "npm run build && npm run build:test && DEBUG=true karma start test/karma.config.js",
-        "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w"
+        "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
+        "watch:tests": "ENVIRONMENT=production rollup --config rollup.test.config.js -w"
+        
     },
     "devDependencies": {
         "@semantic-release/changelog": "^5.0.1",

--- a/src/BingAdsEventForwarder.js
+++ b/src/BingAdsEventForwarder.js
@@ -87,7 +87,9 @@ var constructor = function() {
                             };
                             (obj.q = window[queue]),
                                 (window[queue] = new UET(obj)),
-                                maybeSendConsentUpdateToBing(updatedConsentPayload);
+                                maybeSendConsentUpdateToBing(
+                                    updatedConsentPayload
+                                );
                             window[queue].push('pageLoad');
                         }),
                         (n = document.createElement(tag)),

--- a/src/BingAdsEventForwarder.js
+++ b/src/BingAdsEventForwarder.js
@@ -30,7 +30,7 @@ var MessageType = {
 var bingConsentValues = { Denied: 'denied', Granted: 'granted' };
 var bingConsentProperties = ['ad_storage'];
 var bingToMpConsentSettingsMapping = {
-    ad_storage: 'defaultAdStorageConsentSDK',
+    ad_storage: 'defaultAdStorageConsentWeb',
 };
 
 var constructor = function() {

--- a/src/BingAdsEventForwarder.js
+++ b/src/BingAdsEventForwarder.js
@@ -64,13 +64,6 @@ var constructor = function() {
             self.consentMappings
         );
 
-        var consentPayload;
-        if (!isEmpty(initialConsentPayload)) {
-            consentPayload = initialConsentPayload;
-        } else if (!isEmpty(updatedConsentPayload)) {
-            consentPayload = updatedConsentPayload;
-        }
-
         try {
             if (!testMode) {
                 (function(window, document, tag, url, queue) {
@@ -79,7 +72,7 @@ var constructor = function() {
                     var i;
                     (window[queue] = window[queue] || []),
                         (window.uetq = window.uetq || []),
-                        sendConsentDefaultToBing(consentPayload),
+                        sendConsentDefaultToBing(initialConsentPayload),
                         (f = function() {
                             var obj = {
                                 ti: forwarderSettings.tagId,
@@ -254,9 +247,6 @@ var constructor = function() {
     }
 
     function maybeSendConsentUpdateToBing(consentState) {
-        // If consent payload is empty,
-        // we never sent an initial default consent state
-        // so we shouldn't send an update.
         if (
             self.consentPayloadAsString &&
             self.consentMappings &&

--- a/src/BingAdsEventForwarder.js
+++ b/src/BingAdsEventForwarder.js
@@ -321,6 +321,7 @@ function getConsentSettings(settings) {
 
         // Microsoft recommends that for most countries, we should default to 'Granted'
         // if a default value is not provided
+        // https://help.ads.microsoft.com/apex/index/3/en/60119
         if (bingConsentValuesKey && mpConsentSettingKey) {
             consentSettings[bingConsentKey] = bingConsentValues[
                 bingConsentValuesKey

--- a/src/BingAdsEventForwarder.js
+++ b/src/BingAdsEventForwarder.js
@@ -27,17 +27,51 @@ var MessageType = {
     Commerce: 16,
 };
 
+var bingConsentValues = { Denied: 'denied', Granted: 'granted' };
+var bingConsentProperties = ['ad_storage'];
+var bingToMpConsentSettingsMapping = {
+    ad_storage: 'defaultAdStorageConsentSDK',
+};
+
 var constructor = function() {
     var self = this;
     var isInitialized = false;
     var forwarderSettings = null;
     var reportingService = null;
 
+    self.consentMappings = [];
+    self.consentPayloadAsString = '';
+    self.consentPayloadDefaults = {};
+
     self.name = name;
 
     function initForwarder(settings, service, testMode) {
+        console.warn('BING Local DEV');
+
         forwarderSettings = settings;
         reportingService = service;
+
+        if (forwarderSettings.consentMapingWeb) {
+            self.consentMappings = parseSettingsString(
+                forwarderSettings.consentMapingWeb
+            );
+        }
+        self.consentPayloadDefaults = getConsentSettings(forwarderSettings);
+
+        var initialConsentPayload = cloneObject(self.consentPayloadDefaults);
+        var userConsentState = getUserConsentState();
+
+        var updatedConsentPayload = generateConsentPayload(
+            userConsentState,
+            self.consentMappings
+        );
+
+        var consentPayload;
+        if (!isEmpty(initialConsentPayload)) {
+            consentPayload = initialConsentPayload;
+        } else if (!isEmpty(updatedConsentPayload)) {
+            consentPayload = updatedConsentPayload;
+        }
 
         try {
             if (!testMode) {
@@ -47,6 +81,7 @@ var constructor = function() {
                     var i;
                     (window[queue] = window[queue] || []),
                         (window.uetq = window.uetq || []),
+                        sendConsentDefaultToBing(consentPayload),
                         (f = function() {
                             var obj = {
                                 ti: forwarderSettings.tagId,
@@ -54,7 +89,8 @@ var constructor = function() {
                             };
                             (obj.q = window[queue]),
                                 (window[queue] = new UET(obj)),
-                                window[queue].push('pageLoad');
+                                maybeSendConsentUpdateToBing(consentPayload);
+                            window[queue].push('pageLoad');
                         }),
                         (n = document.createElement(tag)),
                         (n.src = url),
@@ -86,6 +122,7 @@ var constructor = function() {
             isInitialized = true;
             return 'Successfully initialized: ' + name;
         } catch (e) {
+            console.log('error?');
             return "Can't initialize forwarder: " + name + ': ' + e;
         }
     }
@@ -128,9 +165,12 @@ var constructor = function() {
                 "Can't log event on forwarder: " + name + ', not initialized'
             );
         }
-
         try {
             var obj = createUetObject(event, 'pageLoad');
+
+            var eventConsentState = getEventConsentState(event.ConsentState);
+
+            maybeSendConsentUpdateToBing(eventConsentState);
 
             window.uetq.push(obj);
         } catch (e) {
@@ -180,9 +220,124 @@ var constructor = function() {
         return obj;
     }
 
+    function getEventConsentState(eventConsentState) {
+        return eventConsentState && eventConsentState.getGDPRConsentState
+            ? eventConsentState.getGDPRConsentState()
+            : {};
+    }
+
+    function generateConsentPayload(consentState, mappings) {
+        if (!mappings) {
+            return {};
+        }
+
+        var payload = cloneObject(self.consentPayloadDefaults);
+        if (mappings && mappings.length > 0) {
+            for (var i = 0; i < mappings.length; i++) {
+                var mappingEntry = mappings[i];
+                var mpMappedConsentName = mappingEntry.map.toLowerCase();
+                var bingMappedConsentName = mappingEntry.value;
+
+                if (
+                    consentState[mpMappedConsentName] &&
+                    bingConsentProperties.indexOf(bingMappedConsentName) !== -1
+                ) {
+                    payload[bingMappedConsentName] = consentState[
+                        mpMappedConsentName
+                    ].Consented
+                        ? bingConsentValues.Granted
+                        : bingConsentValues.Denied;
+                }
+            }
+        }
+
+        return payload;
+    }
+
+    function maybeSendConsentUpdateToBing(consentState) {
+        // If consent payload is empty,
+        // we never sent an initial default consent state
+        // so we shouldn't send an update.
+        if (
+            self.consentPayloadAsString &&
+            self.consentMappings &&
+            !isEmpty(consentState)
+        ) {
+            var updatedConsentPayload = generateConsentPayload(
+                consentState,
+                self.consentMappings
+            );
+
+            var eventConsentAsString = JSON.stringify(updatedConsentPayload);
+
+            if (eventConsentAsString !== self.consentPayloadAsString) {
+                window.uetq.push('consent', 'update', updatedConsentPayload);
+                self.consentPayloadAsString = JSON.stringify(
+                    updatedConsentPayload
+                );
+            }
+        }
+    }
+
+    function sendConsentDefaultToBing(consentPayload) {
+        self.consentPayloadAsString = JSON.stringify(consentPayload);
+
+        window.uetq.push('consent', 'default', consentPayload);
+    }
+
     this.init = initForwarder;
     this.process = processEvent;
 };
+
+function getUserConsentState() {
+    var userConsentState = {};
+
+    if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
+        var currentUser = mParticle.Identity.getCurrentUser();
+
+        if (!currentUser) {
+            return {};
+        }
+
+        var consentState = mParticle.Identity.getCurrentUser().getConsentState();
+
+        if (consentState && consentState.getGDPRConsentState) {
+            userConsentState = consentState.getGDPRConsentState();
+        }
+    }
+
+    return userConsentState;
+}
+
+function getConsentSettings(settings) {
+    var consentSettings = {};
+
+    Object.keys(bingToMpConsentSettingsMapping).forEach(function(
+        bingConsentKey
+    ) {
+        var mpConsentSettingKey =
+            bingToMpConsentSettingsMapping[bingConsentKey];
+        var bingConsentValuesKey = settings[mpConsentSettingKey];
+
+        // Microsoft recommends that for most countries, we should default to 'Granted'
+        // if a default value is not provided
+        if (bingConsentValuesKey && mpConsentSettingKey) {
+            consentSettings[bingConsentKey] = bingConsentValues[
+                bingConsentValuesKey
+            ]
+                ? bingConsentValues[bingConsentValuesKey]
+                : bingConsentValues.Granted;
+        } else {
+            consentSettings[bingConsentKey] = bingConsentValues.Granted;
+        }
+    });
+
+    return consentSettings;
+}
+
+function parseSettingsString(settingsString) {
+    return JSON.parse(settingsString.replace(/&quot;/g, '"'));
+}
 
 function getId() {
     return moduleId;
@@ -226,6 +381,14 @@ if (typeof window !== 'undefined') {
             getId: getId,
         });
     }
+}
+
+function isEmpty(value) {
+    return value == null || !(Object.keys(value) || value).length;
+}
+
+function cloneObject(obj) {
+    return JSON.parse(JSON.stringify(obj));
 }
 
 module.exports = {

--- a/src/BingAdsEventForwarder.js
+++ b/src/BingAdsEventForwarder.js
@@ -46,14 +46,12 @@ var constructor = function() {
     self.name = name;
 
     function initForwarder(settings, service, testMode) {
-        console.warn('BING Local DEV');
-
         forwarderSettings = settings;
         reportingService = service;
 
-        if (forwarderSettings.consentMapingWeb) {
+        if (forwarderSettings.consentMappingWeb) {
             self.consentMappings = parseSettingsString(
-                forwarderSettings.consentMapingWeb
+                forwarderSettings.consentMappingWeb
             );
         }
         self.consentPayloadDefaults = getConsentSettings(forwarderSettings);
@@ -89,7 +87,7 @@ var constructor = function() {
                             };
                             (obj.q = window[queue]),
                                 (window[queue] = new UET(obj)),
-                                maybeSendConsentUpdateToBing(consentPayload);
+                                maybeSendConsentUpdateToBing(updatedConsentPayload);
                             window[queue].push('pageLoad');
                         }),
                         (n = document.createElement(tag)),
@@ -122,7 +120,6 @@ var constructor = function() {
             isInitialized = true;
             return 'Successfully initialized: ' + name;
         } catch (e) {
-            console.log('error?');
             return "Can't initialize forwarder: " + name + ': ' + e;
         }
     }

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -93,7 +93,6 @@ describe('Bing Ads Event Forwarder', function() {
 
             // UETQ queues up events as array elements and then parses them internally.
             // The first 3 elements of this array will be the consent payload
-            // The 4th element will be the event payload
             window.uetq.length.should.eql(3);
             window.uetq[0].should.equal('consent');
             window.uetq[1].should.equal('default');
@@ -193,7 +192,7 @@ describe('Bing Ads Event Forwarder', function() {
             window.uetq = [];
         });
 
-        it('should consolidate consent information', function(done) {
+        it('should consent information to window.uetq', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -250,7 +249,7 @@ describe('Bing Ads Event Forwarder', function() {
             done();
         });
 
-        it('should construct a Default Consent State Payload from Mappings on init', function(done) {
+        it('should construct a Default Consent State Payload of `granted` from Mappings when `defaultAdStorageConsentWeb` is undefined', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -270,11 +269,7 @@ describe('Bing Ads Event Forwarder', function() {
             // UETQ queues up events as array elements and then parses them internally.
             // The first 3 elements of this array will be the consent payload
             window.uetq.length.should.eql(3);
-            window.uetq.should.eql([
-                'consent',
-                'default',
-                expectedConsentPayload[2],
-            ]);
+            window.uetq.should.eql(expectedConsentPayload);
 
             done();
         });
@@ -303,9 +298,7 @@ describe('Bing Ads Event Forwarder', function() {
             ];
 
             window.uetq.length.should.eql(3);
-            window.uetq[0].should.equal('consent');
-            window.uetq[1].should.equal('default');
-            window.uetq[2].should.eql(expectedInitialConsentPayload[2]);
+            window.uetq.should.eql(expectedInitialConsentPayload);
 
             var obj = {
                 EventDataType: MessageType.PageEvent,
@@ -371,13 +364,11 @@ describe('Bing Ads Event Forwarder', function() {
             ];
 
             window.uetq.length.should.eql(3);
-            window.uetq[0].should.equal('consent');
-            window.uetq[1].should.equal('default');
-            window.uetq[2].should.eql(expectedConsentPayload[2]);
+            window.uetq.should.eql(expectedConsentPayload);
             done();
         });
 
-        it('should construct a Consent State Update Payload when consent changes', function(done) {
+        it('should construct a Consent State Update Payload when consent changes and defaultAdStorageConsentWeb is undefined', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -453,7 +444,7 @@ describe('Bing Ads Event Forwarder', function() {
             done();
         });
 
-        it('should construct a Consent State Update Payload with Consent Setting Defaults when consent changes', function(done) {
+        it('should construct a Consent State Update Payload when consent changes', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -587,7 +578,7 @@ describe('Bing Ads Event Forwarder', function() {
 
             mParticle.forwarder.process(obj);
 
-            // UETQ should now have 7 elements
+            // UETQ should now have 4 elements
             // The first 3 elements of this array will be the initial consent payload
             // The 4th element will be the event payload
 
@@ -624,51 +615,6 @@ describe('Bing Ads Event Forwarder', function() {
             window.uetq[0].should.equal('consent');
             window.uetq[1].should.equal('default');
             window.uetq[2].should.eql(expectedInitialConsentPayload[2]);
-
-            var obj = {
-                EventDataType: MessageType.PageEvent,
-                EventName: 'Test Page Event',
-                CustomFlags: {
-                    'Bing.EventValue': 10,
-                },
-                ConsentState: {
-                    getGDPRConsentState: function() {
-                        return {
-                            marketing_consent: {
-                                Consented: true,
-                                Timestamp: 1557935884509,
-                                ConsentDocument: 'Marketing_Consent',
-                                Location: 'This is fake',
-                                HardwareId: '123456',
-                            },
-                        };
-                    },
-
-                    getCCPAConsentState: function() {
-                        return {
-                            data_sale_opt_out: {
-                                Consented: false,
-                                Timestamp: Date.now(),
-                                Document: 'some_consent',
-                            },
-                        };
-                    },
-                },
-            };
-
-            mParticle.forwarder.process(obj);
-
-            // UETQ should now have 7 elements
-            // The first 3 elements of this array will be the initial consent payload
-            // The 4th element will be the event payload
-
-            window.uetq.length.should.eql(4);
-            window.uetq[3].should.eql({
-                ea: 'pageLoad',
-                ec: 'This is my name!',
-                el: 'Test Page Event',
-                ev: 10,
-            });
 
             done();
         });
@@ -730,7 +676,7 @@ describe('Bing Ads Event Forwarder', function() {
 
             mParticle.forwarder.process(obj);
 
-            // UETQ should now have 7 elements
+            // UETQ should now have 4 elements
             // The first 3 elements of this array will be the initial consent payload
             // The 4th element will be the event payload
 

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -254,7 +254,7 @@ describe('Bing Ads Event Forwarder', function() {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
-                    consentMapingWeb:
+                    consentMappingWeb:
                         '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Marketing&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;}]',
                 },
                 reportService.cb,
@@ -283,7 +283,7 @@ describe('Bing Ads Event Forwarder', function() {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
-                    consentMapingWeb: JSON.stringify(consentMap),
+                    consentMappingWeb: JSON.stringify(consentMap),
                     defaultAdStorageConsentWeb: 'Denied', // Should be overridden by user consent state
                 },
                 reportService.cb,
@@ -357,7 +357,7 @@ describe('Bing Ads Event Forwarder', function() {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
-                    consentMapingWeb: JSON.stringify(consentMap),
+                    consentMappingWeb: JSON.stringify(consentMap),
                     defaultAdStorageConsentWeb: 'Unspecified', // Should be overridden by user consent state
                 },
                 reportService.cb,
@@ -383,7 +383,7 @@ describe('Bing Ads Event Forwarder', function() {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
-                    consentMapingWeb: JSON.stringify(consentMap),
+                    consentMappingWeb: JSON.stringify(consentMap),
                 },
                 reportService.cb,
                 false // Disable testMode so we can test init
@@ -459,7 +459,7 @@ describe('Bing Ads Event Forwarder', function() {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
-                    consentMapingWeb: JSON.stringify(consentMap),
+                    consentMappingWeb: JSON.stringify(consentMap),
                     defaultAdStorageConsentWeb: 'Denied',
                 },
                 reportService.cb,
@@ -536,7 +536,7 @@ describe('Bing Ads Event Forwarder', function() {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
-                    consentMapingWeb: JSON.stringify(consentMap),
+                    consentMappingWeb: JSON.stringify(consentMap),
                 },
                 reportService.cb,
                 false // Disable testMode so we can test init

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -63,7 +63,6 @@ describe('Bing Ads Event Forwarder', function () {
     beforeEach(function () {
         reportService.reset();
         window.uetq = [];
-
     });
 
     describe('Init the BingAds SDK', function () {
@@ -89,7 +88,7 @@ describe('Bing Ads Event Forwarder', function () {
                     tagId: 'tagId',
                 },
                 reportService.cb,
-                false, // Disable testMode so we can test init
+                false // Disable testMode so we can test init
             );
 
             // UETQ queues up events as array elements and then parses them internally.
@@ -200,7 +199,7 @@ describe('Bing Ads Event Forwarder', function () {
                     tagId: 'tagId',
                 },
                 reportService.cb,
-                false, // Disable testMode so we can test init
+                false // Disable testMode so we can test init
             );
 
             var obj = {
@@ -271,12 +270,16 @@ describe('Bing Ads Event Forwarder', function () {
             // UETQ queues up events as array elements and then parses them internally.
             // The first 3 elements of this array will be the consent payload
             window.uetq.length.should.eql(3);
-            window.uetq.should.eql(['consent', 'default', expectedConsentPayload[2]]);
+            window.uetq.should.eql([
+                'consent',
+                'default',
+                expectedConsentPayload[2],
+            ]);
 
             done();
         });
 
-        it('should construct a Default Consent State Payload from Default Settings and construct an Update Consent State Payload from Mappings', (done) => {
+        it('should construct a Default Consent State Payload from Default Settings and construct an Update Consent State Payload from Mappings', function (done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -293,7 +296,6 @@ describe('Bing Ads Event Forwarder', function () {
                 { ad_storage: 'denied' },
             ];
 
-
             var expectedUpdatedConsentPayload = [
                 'consent',
                 'update',
@@ -304,7 +306,6 @@ describe('Bing Ads Event Forwarder', function () {
             window.uetq[0].should.equal('consent');
             window.uetq[1].should.equal('default');
             window.uetq[2].should.eql(expectedInitialConsentPayload[2]);
-
 
             var obj = {
                 EventDataType: MessageType.PageEvent,
@@ -352,7 +353,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should ignore Unspecified Consent Settings if NOT explicitly defined in Consent State', (done) => {
+        it('should ignore Unspecified Consent Settings if NOT explicitly defined in Consent State', function (done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -378,7 +379,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should construct a Consent State Update Payload when consent changes', (done) => {
+        it('should construct a Consent State Update Payload when consent changes', function (done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -454,7 +455,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should construct a Consent State Update Payload with Consent Setting Defaults when consent changes', (done) => {
+        it('should construct a Consent State Update Payload with Consent Setting Defaults when consent changes', function (done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -531,8 +532,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should NOT construct a Consent State Update Payload if consent DOES NOT change', (done) => {
-
+        it('should NOT construct a Consent State Update Payload if consent DOES NOT change', function (done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -610,8 +610,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should create a Consent State Default of Granted if consent mappings and settings are undefined', (done) => {
-
+        it('should create a Consent State Default of Granted if consent mappings and settings are undefined', function (done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -682,8 +681,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should construct Consent State Payloads if consent mappings is undefined but settings defaults are defined', (done) => {
-
+        it('should construct Consent State Payloads if consent mappings is undefined but settings defaults are defined', function (done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -370,8 +370,6 @@ describe('Bing Ads Event Forwarder', function() {
                 { ad_storage: 'granted' },
             ];
 
-            console.log('uetq', window.uetq);
-
             window.uetq.length.should.eql(3);
             window.uetq[0].should.equal('consent');
             window.uetq[1].should.equal('default');

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -589,6 +589,7 @@ describe('Bing Ads Event Forwarder', function() {
                 el: 'Test Page Event',
                 ev: 10,
             });
+            window.uetq.indexOf('update').should.equal(-1);
 
             done();
         });

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -619,7 +619,7 @@ describe('Bing Ads Event Forwarder', function() {
             done();
         });
 
-        it('should construct Consent State Payloads if consent mappings is undefined but settings defaults are defined', function(done) {
+        it('should ONLY construct Default Consent State Payloads if consent mappings is undefined but settings defaults are defined and consent does not change', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -1,15 +1,15 @@
-describe('Bing Ads Event Forwarder', function () {
-    var ReportingService = function () {
+describe('Bing Ads Event Forwarder', function() {
+    var ReportingService = function() {
         var self = this;
         this.id = null;
         this.event = null;
 
-        this.cb = function (forwarder, event) {
+        this.cb = function(forwarder, event) {
             self.id = forwarder.id;
             self.event = event;
         };
 
-        this.reset = function () {
+        this.reset = function() {
             self.id = null;
             self.event = null;
         };
@@ -32,7 +32,7 @@ describe('Bing Ads Event Forwarder', function () {
         Social: 7,
         Other: 8,
         Media: 9,
-        getName: function () {
+        getName: function() {
             return 'This is my name!';
         },
     };
@@ -48,25 +48,25 @@ describe('Bing Ads Event Forwarder', function () {
         Refund: 8,
         AddToWishlist: 9,
         RemoveFromWishlist: 10,
-        getName: function () {
+        getName: function() {
             return 'Action';
         },
     };
     var reportService = new ReportingService();
 
-    before(function () {
+    before(function() {
         mParticle.EventType = EventType;
         mParticle.MessageType = MessageType;
         mParticle.ProductActionType = ProductActionType;
     });
 
-    beforeEach(function () {
+    beforeEach(function() {
         reportService.reset();
         window.uetq = [];
     });
 
-    describe('Init the BingAds SDK', function () {
-        beforeEach(function () {
+    describe('Init the BingAds SDK', function() {
+        beforeEach(function() {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -76,13 +76,13 @@ describe('Bing Ads Event Forwarder', function () {
             );
         });
 
-        it('should init', function (done) {
+        it('should init', function(done) {
             window.uetq.length.should.equal(0);
 
             done();
         });
 
-        it('should init with a consent payload', function (done) {
+        it('should init with a consent payload', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -105,8 +105,8 @@ describe('Bing Ads Event Forwarder', function () {
         });
     });
 
-    describe('Track Events', function () {
-        beforeEach(function () {
+    describe('Track Events', function() {
+        beforeEach(function() {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -116,7 +116,7 @@ describe('Bing Ads Event Forwarder', function () {
             );
         });
 
-        it('should log events', function (done) {
+        it('should log events', function(done) {
             var obj = {
                 EventDataType: MessageType.PageEvent,
                 EventName: 'Test Page Event',
@@ -134,7 +134,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should log commerce events', function (done) {
+        it('should log commerce events', function(done) {
             var obj = {
                 EventDataType: MessageType.Commerce,
                 EventName: 'Test Commerce Event',
@@ -154,7 +154,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should not log event without an event name', function (done) {
+        it('should not log event without an event name', function(done) {
             mParticle.forwarder.process({
                 EventDataType: '',
             });
@@ -164,7 +164,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should not log incorrect events', function (done) {
+        it('should not log incorrect events', function(done) {
             mParticle.forwarder.process({
                 EventDataType: MessageType.Commerce,
             });
@@ -175,7 +175,7 @@ describe('Bing Ads Event Forwarder', function () {
         });
     });
 
-    describe('Consent', function () {
+    describe('Consent', function() {
         var consentMap = [
             {
                 jsmap: null,
@@ -185,15 +185,15 @@ describe('Bing Ads Event Forwarder', function () {
             },
         ];
 
-        beforeEach(function () {
+        beforeEach(function() {
             mParticle.forwarders = [];
         });
 
-        afterEach(function () {
+        afterEach(function() {
             window.uetq = [];
         });
 
-        it('should consolidate consent information', function (done) {
+        it('should consolidate consent information', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -209,7 +209,7 @@ describe('Bing Ads Event Forwarder', function () {
                     'Bing.EventValue': 10,
                 },
                 ConsentState: {
-                    getGDPRConsentState: function () {
+                    getGDPRConsentState: function() {
                         return {
                             some_consent: {
                                 Consented: true,
@@ -250,7 +250,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should construct a Default Consent State Payload from Mappings on init', function (done) {
+        it('should construct a Default Consent State Payload from Mappings on init', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -279,7 +279,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should construct a Default Consent State Payload from Default Settings and construct an Update Consent State Payload from Mappings', function (done) {
+        it('should construct a Default Consent State Payload from Default Settings and construct an Update Consent State Payload from Mappings', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -314,7 +314,7 @@ describe('Bing Ads Event Forwarder', function () {
                     'Bing.EventValue': 10,
                 },
                 ConsentState: {
-                    getGDPRConsentState: function () {
+                    getGDPRConsentState: function() {
                         return {
                             marketing_consent: {
                                 Consented: true,
@@ -326,7 +326,7 @@ describe('Bing Ads Event Forwarder', function () {
                         };
                     },
 
-                    getCCPAConsentState: function () {
+                    getCCPAConsentState: function() {
                         return {
                             data_sale_opt_out: {
                                 Consented: false,
@@ -353,7 +353,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should ignore Unspecified Consent Settings if NOT explicitly defined in Consent State', function (done) {
+        it('should ignore Unspecified Consent Settings if NOT explicitly defined in Consent State', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -379,7 +379,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should construct a Consent State Update Payload when consent changes', function (done) {
+        it('should construct a Consent State Update Payload when consent changes', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -416,7 +416,7 @@ describe('Bing Ads Event Forwarder', function () {
                     'Bing.EventValue': 10,
                 },
                 ConsentState: {
-                    getGDPRConsentState: function () {
+                    getGDPRConsentState: function() {
                         return {
                             marketing_consent: {
                                 Consented: false,
@@ -428,7 +428,7 @@ describe('Bing Ads Event Forwarder', function () {
                         };
                     },
 
-                    getCCPAConsentState: function () {
+                    getCCPAConsentState: function() {
                         return {
                             data_sale_opt_out: {
                                 Consented: false,
@@ -455,7 +455,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should construct a Consent State Update Payload with Consent Setting Defaults when consent changes', function (done) {
+        it('should construct a Consent State Update Payload with Consent Setting Defaults when consent changes', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -493,7 +493,7 @@ describe('Bing Ads Event Forwarder', function () {
                     'Bing.EventValue': 10,
                 },
                 ConsentState: {
-                    getGDPRConsentState: function () {
+                    getGDPRConsentState: function() {
                         return {
                             marketing_consent: {
                                 Consented: true,
@@ -505,7 +505,7 @@ describe('Bing Ads Event Forwarder', function () {
                         };
                     },
 
-                    getCCPAConsentState: function () {
+                    getCCPAConsentState: function() {
                         return {
                             data_sale_opt_out: {
                                 Consented: false,
@@ -532,7 +532,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should NOT construct a Consent State Update Payload if consent DOES NOT change', function (done) {
+        it('should NOT construct a Consent State Update Payload if consent DOES NOT change', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -548,12 +548,6 @@ describe('Bing Ads Event Forwarder', function () {
                 { ad_storage: 'granted' },
             ];
 
-            var expectedUpdatedConsentPayload = [
-                'consent',
-                'update',
-                { ad_storage: 'denied' },
-            ];
-
             // UETQ queues up events as array elements and then parses them internally.
             // The first 3 elements of this array will be the consent payload
 
@@ -569,7 +563,7 @@ describe('Bing Ads Event Forwarder', function () {
                     'Bing.EventValue': 10,
                 },
                 ConsentState: {
-                    getGDPRConsentState: function () {
+                    getGDPRConsentState: function() {
                         return {
                             marketing_consent: {
                                 Consented: true,
@@ -581,7 +575,7 @@ describe('Bing Ads Event Forwarder', function () {
                         };
                     },
 
-                    getCCPAConsentState: function () {
+                    getCCPAConsentState: function() {
                         return {
                             data_sale_opt_out: {
                                 Consented: false,
@@ -610,7 +604,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should create a Consent State Default of Granted if consent mappings and settings are undefined', function (done) {
+        it('should create a Consent State Default of Granted if consent mappings and settings are undefined', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -640,7 +634,7 @@ describe('Bing Ads Event Forwarder', function () {
                     'Bing.EventValue': 10,
                 },
                 ConsentState: {
-                    getGDPRConsentState: function () {
+                    getGDPRConsentState: function() {
                         return {
                             marketing_consent: {
                                 Consented: true,
@@ -652,7 +646,7 @@ describe('Bing Ads Event Forwarder', function () {
                         };
                     },
 
-                    getCCPAConsentState: function () {
+                    getCCPAConsentState: function() {
                         return {
                             data_sale_opt_out: {
                                 Consented: false,
@@ -681,7 +675,7 @@ describe('Bing Ads Event Forwarder', function () {
             done();
         });
 
-        it('should construct Consent State Payloads if consent mappings is undefined but settings defaults are defined', function (done) {
+        it('should construct Consent State Payloads if consent mappings is undefined but settings defaults are defined', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
@@ -712,7 +706,7 @@ describe('Bing Ads Event Forwarder', function () {
                     'Bing.EventValue': 10,
                 },
                 ConsentState: {
-                    getGDPRConsentState: function () {
+                    getGDPRConsentState: function() {
                         return {
                             marketing_consent: {
                                 Consented: false,
@@ -724,7 +718,7 @@ describe('Bing Ads Event Forwarder', function () {
                         };
                     },
 
-                    getCCPAConsentState: function () {
+                    getCCPAConsentState: function() {
                         return {
                             data_sale_opt_out: {
                                 Consented: false,

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -346,7 +346,7 @@ describe('Bing Ads Event Forwarder', function() {
             done();
         });
 
-        it('should ignore Unspecified Consent Settings if NOT explicitly defined in Consent State', function(done) {
+        it('should default to `granted` if Consent Settings are `Unspecified`', function(done) {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',

--- a/test/src/tests.js
+++ b/test/src/tests.js
@@ -284,7 +284,7 @@ describe('Bing Ads Event Forwarder', function() {
                 {
                     tagId: 'tagId',
                     consentMapingWeb: JSON.stringify(consentMap),
-                    defaultAdStorageConsentSDK: 'Denied', // Should be overridden by user consent state
+                    defaultAdStorageConsentWeb: 'Denied', // Should be overridden by user consent state
                 },
                 reportService.cb,
                 false // Disable testMode so we can test init
@@ -358,7 +358,7 @@ describe('Bing Ads Event Forwarder', function() {
                 {
                     tagId: 'tagId',
                     consentMapingWeb: JSON.stringify(consentMap),
-                    defaultAdStorageConsentSDK: 'Unspecified', // Should be overridden by user consent state
+                    defaultAdStorageConsentWeb: 'Unspecified', // Should be overridden by user consent state
                 },
                 reportService.cb,
                 false // Disable testMode so we can test init
@@ -460,7 +460,7 @@ describe('Bing Ads Event Forwarder', function() {
                 {
                     tagId: 'tagId',
                     consentMapingWeb: JSON.stringify(consentMap),
-                    defaultAdStorageConsentSDK: 'Denied',
+                    defaultAdStorageConsentWeb: 'Denied',
                 },
                 reportService.cb,
                 false // Disable testMode so we can test init
@@ -679,7 +679,7 @@ describe('Bing Ads Event Forwarder', function() {
             mParticle.forwarder.init(
                 {
                     tagId: 'tagId',
-                    defaultAdStorageConsentSDK: 'Denied',
+                    defaultAdStorageConsentWeb: 'Denied',
                 },
                 reportService.cb,
                 false // Disable testMode so we can test init


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Adds consent defaults and consent updates for Bing Ads events according to [Microsoft's Documentation](https://help.ads.microsoft.com/apex/index/3/en/60119)

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Load up the Kit in a sample app and fire events
 - In the network tab, all events that go to Bing should now have a new property `ASC` with a `G` for consent Granted and `D` for Consent Denied

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6745
